### PR TITLE
Oauth Token Refresh

### DIFF
--- a/app/api/v1/auth/dto.go
+++ b/app/api/v1/auth/dto.go
@@ -24,3 +24,9 @@ type loginResponseDto struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
 }
+
+type oauthRefreshTokenResponseDto struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type" default:"Bearer"`
+}

--- a/app/api/v1/auth/handlers.go
+++ b/app/api/v1/auth/handlers.go
@@ -116,6 +116,7 @@ func (hdl *authRouter) oauthToken(ctx *gin.Context) {
 		response := oauthRefreshTokenResponseDto{
 			AccessToken:  accessToken,
 			RefreshToken: refreshToken,
+			TokenType:    "Bearer",
 		}
 
 		ctx.JSON(http.StatusOK, response)

--- a/app/api/v1/auth/handlers.go
+++ b/app/api/v1/auth/handlers.go
@@ -77,3 +77,49 @@ func (hdl *authRouter) login(ctx *gin.Context) {
 
 	ctx.JSON(http.StatusOK, response)
 }
+
+// oauthToken refreshes a token given a refresh token
+func (hdl *authRouter) oauthToken(ctx *gin.Context) {
+	grantType := ctx.Query("grant_type")
+	refreshToken := ctx.Query("refresh_token")
+
+	if grantType == "refresh_token" {
+		if len(refreshToken) == 0 {
+			ctx.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+
+		uid, _, err := hdl.authSvc.Authenticate(refreshToken)
+
+		if err != nil {
+			ctx.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": err.Error()})
+			return
+		}
+
+		if _, err := hdl.svc.GetUserByID(uid); err != nil {
+			ctx.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": err.Error()})
+			return
+		}
+
+		accessToken, err := hdl.authSvc.GenerateToken(uid)
+		if err != nil {
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+			return
+		}
+
+		refreshToken, err := hdl.authSvc.GenerateRefreshToken(uid)
+		if err != nil {
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+			return
+		}
+
+		response := oauthRefreshTokenResponseDto{
+			AccessToken:  accessToken,
+			RefreshToken: refreshToken,
+		}
+
+		ctx.JSON(http.StatusOK, response)
+	} else {
+		ctx.AbortWithStatus(http.StatusUnauthorized)
+	}
+}

--- a/app/api/v1/auth/router.go
+++ b/app/api/v1/auth/router.go
@@ -32,5 +32,6 @@ func (hdl *authRouter) initRoutes() {
 	hdl.routes = []router.Route{
 		router.NewPostRoute(fmt.Sprintf("%s/auth/register", hdl.baseUri), hdl.register),
 		router.NewPostRoute(fmt.Sprintf("%s/auth/login", hdl.baseUri), hdl.login),
+		router.NewPostRoute(fmt.Sprintf("%s/auth/oauth/token", hdl.baseUri), hdl.oauthToken),
 	}
 }

--- a/app/internal/repositories/repo.go
+++ b/app/internal/repositories/repo.go
@@ -2,7 +2,6 @@ package repositories
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/sanctumlabs/curtz/app/config"
 	urlRepo "github.com/sanctumlabs/curtz/app/internal/repositories/urlrepo"
@@ -26,15 +25,15 @@ type Repository struct {
 // NewRepository creates a new repository with provided config
 func NewRepository(config config.DatabaseConfig) *Repository {
 	defer monitoring.ErrorHandler()
-	var uri string
+	clientOptions := options.Client()
 
-	if config.IsSRV {
-		uri = fmt.Sprintf("mongodb+srv://%s:%s@%s", config.User, config.Password, config.Host)	
-	} else {
-		uri = fmt.Sprintf("mongodb://%s:%s@%s:%s", config.User, config.Password, config.Host, config.Port)
+	auth := options.Credential{
+		Username: config.User,
+		Password: config.Password,
 	}
 
-	clientOptions := options.Client().ApplyURI(uri)
+	clientOptions.Hosts = []string{config.Host}
+	clientOptions.SetAuth(auth)
 	clientOptions.SetRetryWrites(true)
 
 	dbClient, err := mongo.NewClient(clientOptions)

--- a/app/server/middleware/auth.go
+++ b/app/server/middleware/auth.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	healthRegex = regexp.MustCompile("^(/health)$")
-	authRegex   = regexp.MustCompile("^/api/v[0-9]+/curtz/auth/(register|login)$")
+	authRegex   = regexp.MustCompile("^/api/v[0-9]+/curtz/auth/(register|login|oauth/token)$")
 	clientRegex = regexp.MustCompile(`^/[a-zA-Z0-9]+$|/auth/verify(/\?v=[a-zA-Z0-9]+)*`)
 )
 


### PR DESCRIPTION
# Description

Adds a new Oauth Token refresh endpoint to allow getting a new access token from a valid refresh token

Fixes #15

## Resolution/What did you add?

- Oauth Refresh token endpoint
- Unit tests to validate new handler 
- Update regex in auth middleware to allow Oauth Access token to bypass Auth Header
- Check expiration time of jwt token in JWT package


## Additional Release Steps

None required

## How can we test this?

- Run unit tests with `make test`
- Run application by first running `docker compose up`
- Run application with `make run`, optionally run in debug mode from your IDE.
- Create a user if none exists.
- Login with that user to get a token
- Access the new endpoint passing in the refresh token in the query params. A new access and refresh token should be issued.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
- [x] Is my code backwards compatible
- [x] Have I written unit tests